### PR TITLE
[TEP-0056]: Initial set of API refactors pertinent to Pipelines in Pipelines

### DIFF
--- a/docs/pipelines-in-pipelines.md
+++ b/docs/pipelines-in-pipelines.md
@@ -1,0 +1,109 @@
+<!--
+---
+linkTitle: "Pipelines in Pipelines"
+weight: 406
+---
+-->
+
+# Pipelines in Pipelines
+> 🌱 Pipelines in Pipelines is an alpha feature. The enable-api-fields feature flag must be set to "alpha" to specify PipelineRef or PipelineSpec in a PipelineTask.
+>
+> This feature is in Preview Only mode and not yet supported/implemented.
+
+* [Overview](#overview)
+* [Specifying `pipelineRef` in `Tasks`](#specifying-pipelineref-in-tasks)
+* [Specifying `pipelineSpec` in `Tasks`](#specifying-pipelinespec-in-tasks)
+* [Specifying `Parameters`](#specifying-parameters)
+
+## Overview
+A mechanism to define and execute Pipelines in Pipelines, alongside Tasks and Custom Tasks, for a more in-depth background and inspiration, refer to the proposal [TEP-0056](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md "Proposal")
+
+## Specifying `pipelineRef` in `Tasks`
+Defining Pipelines in Pipelines at authoring time, by either specifying `PipelineRef` or `PipelineSpec` fields to a `PipelineTask` alongside `TaskRef` and `TaskSpec`.
+
+For example, a Pipeline named security-scans which is run within a Pipeline named clone-scan-notify where the PipelineRef is used:
+```
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: security-scans
+spec:
+  tasks:
+    - name: scorecards
+      taskRef:
+        name: scorecards
+    - name: codeql
+      taskRef:
+        name: codeql
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: clone-scan-notify
+spec:
+  tasks:
+    - name: git-clone
+      taskRef:
+        name: git-clone
+    - name: security-scans
+      pipelineRef:
+        name: security-scans
+    - name: notification
+      taskRef:
+        name: notification
+```
+
+## Specifying `pipelineSpec` in `Tasks`
+The `pipelineRef` [example](#specifying-pipelineref-in-tasks) can be modified to use PipelineSpec instead of PipelineRef to instead embed the Pipeline specification:
+```
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: clone-scan-notify
+spec:
+  tasks:
+    - name: git-clone
+      taskRef:
+        name: git-clone
+    - name: security-scans
+      pipelineSpec:
+        tasks:
+          - name: scorecards
+            taskRef:
+              name: scorecards
+          - name: codeql
+            taskRef:
+              name: codeql
+    - name: notification
+      taskRef:
+        name: notification
+```
+
+## Specifying `Parameters`
+Pipelines in Pipelines consume Parameters in the same way as Tasks in Pipelines
+```
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: clone-scan-notify
+spec:
+  params:
+    - name: repo
+      value: $(params.repo)
+  tasks:
+    - name: git-clone
+      params:
+        - name: repo
+          value: $(params.repo)      
+      taskRef:
+        name: git-clone
+    - name: security-scans
+      params:
+        - name: repo
+          value: $(params.repo)
+      pipelineRef:
+        name: security-scans
+    - name: notification
+      taskRef:
+        name: notification
+```

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -26,6 +26,7 @@ weight: 203
         - [Compose using Pipelines in Pipelines](#compose-using-pipelines-in-pipelines)
       - [Guarding a `Task` only](#guarding-a-task-only)
     - [Configuring the failure timeout](#configuring-the-failure-timeout)
+	- [Pipelines in Pipelines](#pipelines-in-pipelines)
   - [Using variable substitution](#using-variable-substitution)
     - [Using the `retries` and `retry-count` variable substitutions](#using-the-retries-and-retry-count-variable-substitutions)
   - [Using `Results`](#using-results)
@@ -849,6 +850,53 @@ spec:
         name: build-push
       timeout: "0h1m30s"
 ```
+
+### Pipelines in Pipelines
+> 🌱 Pipelines in Pipelines is an alpha feature. The enable-api-fields feature flag must be set to "alpha" to specify PipelineRef or PipelineSpec in a PipelineTask. This feature is in Preview Only mode and not yet supported/implemented
+
+Referencing a pipeline in a pipeline
+```
+kind: Pipeline
+metadata:
+  name: security-scans
+spec:
+  tasks:
+    - name: scorecards
+      taskSpec:
+        steps:
+          - image: alpine
+            name: step-1
+            script: |
+              echo "Generating scorecard report ..."
+    - name: codeql
+      taskSpec:
+        steps:
+          - image: alpine
+            name: step-1
+            script: |
+              echo "Generating codeql report ..."
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: clone-scan-notify
+spec:
+  tasks:
+    - name: git-clone
+      taskSpec:
+        steps:
+          - image: alpine
+            name: step-1
+            script: |
+              echo "Cloning a repo to run security scans ..."
+    - name: security-scans
+      runAfter:
+        - git-clone
+      pipelineRef:
+        name: security-scans
+---
+```
+For further information read [Pipelines in Pipelines](./pipelines-in-pipelines.md)
 
 ## Using variable substitution
 

--- a/examples/v1/pipelineruns/no-ci/pipelinerun-with-pipelines-in-pipelines.yaml
+++ b/examples/v1/pipelineruns/no-ci/pipelinerun-with-pipelines-in-pipelines.yaml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: security-scans
+spec:
+  tasks:
+    - name: scorecards
+      taskSpec:
+        steps:
+          - image: alpine
+            name: step-1
+            script: |
+              echo "Generating scorecard report ..."
+    - name: codeql
+      taskSpec:
+        steps:
+          - image: alpine
+            name: step-1
+            script: |
+              echo "Generating codeql report ..."
+---
+
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: clone-scan-notify
+spec:
+  tasks:
+    - name: git-clone
+      taskSpec:
+        steps:
+          - image: alpine
+            name: step-1
+            script: |
+              echo "Cloning a repo to run security scans ..."
+    - name: security-scans
+      runAfter:
+        - git-clone
+      pipelineRef:
+        name: security-scans
+---
+
+
+apiVersion: tekon.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: pipeline-in-pipeline-
+spec:
+  pipelineRef:
+    name: clone-scan-notify

--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -228,6 +228,16 @@ type PipelineTask struct {
 	// Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
+
+	// PipelineRef is a reference to a pipeline definition
+	// Note: PipelineRef is in preview mode and not yet supported
+	// +optional
+	PipelineRef *PipelineRef `json:"pipelineRef,omitempty"`
+
+	// PipelineSpec is a specification of a pipeline
+	// Note: PipelineSpec is in preview mode and not yet supported
+	// +optional
+	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
 }
 
 // IsCustomTask checks whether an embedded TaskSpec is a Custom Task

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -90,13 +90,25 @@ func TestPipelineTask_ValidateRefOrSpec(t *testing.T) {
 			TaskSpec: &EmbeddedTask{},
 		},
 	}, {
-		name: "invalid pipeline task missing taskRef and taskSpec",
+		name: "valid pipeline task - with pipelineRef only",
+		p: PipelineTask{
+			Name:        "foo",
+			PipelineRef: &PipelineRef{},
+		},
+	}, {
+		name: "valid pipeline task - with pipelineSpec only",
+		p: PipelineTask{
+			Name:         "foo",
+			PipelineSpec: &PipelineSpec{},
+		},
+	}, {
+		name: "invalid pipeline task missing taskRef or taskSpec or pipelineRef or pipelineSpec",
 		p: PipelineTask{
 			Name: "foo",
 		},
 		expectedError: &apis.FieldError{
 			Message: `expected exactly one, got neither`,
-			Paths:   []string{"taskRef", "taskSpec"},
+			Paths:   []string{"taskRef", "taskSpec", "pipelineRef", "pipelineSpec"},
 		},
 	}, {
 		name: "invalid pipeline task with both taskRef and taskSpec",
@@ -106,8 +118,124 @@ func TestPipelineTask_ValidateRefOrSpec(t *testing.T) {
 			TaskSpec: &EmbeddedTask{TaskSpec: getTaskSpec()},
 		},
 		expectedError: &apis.FieldError{
-			Message: `expected exactly one, got both`,
+			Message: `expected exactly one, got multiple`,
 			Paths:   []string{"taskRef", "taskSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with both taskRef and pipelineRef",
+		p: PipelineTask{
+			Name:        "foo",
+			TaskRef:     &TaskRef{Name: "foo-task"},
+			PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskRef", "pipelineRef"},
+		},
+	}, {
+		name: "invalid pipeline task with both taskRef and pipelineSpec",
+		p: PipelineTask{
+			Name:         "foo",
+			TaskRef:      &TaskRef{Name: "foo-task"},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskRef", "pipelineSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with both taskSpec and pipelineRef",
+		p: PipelineTask{
+			Name:        "foo",
+			TaskSpec:    &EmbeddedTask{TaskSpec: getTaskSpec()},
+			PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskSpec", "pipelineRef"},
+		},
+	}, {
+		name: "invalid pipeline task with both taskSpec and pipelineSpec",
+		p: PipelineTask{
+			Name:         "foo",
+			TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskSpec", "pipelineSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with both pipelineRef and pipelineSpec",
+		p: PipelineTask{
+			Name:         "foo",
+			PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"pipelineRef", "pipelineSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with taskRef and taskSpec and pipelineRef",
+		p: PipelineTask{
+			Name:        "foo",
+			TaskRef:     &TaskRef{Name: "foo-task"},
+			TaskSpec:    &EmbeddedTask{TaskSpec: getTaskSpec()},
+			PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskRef", "taskSpec", "pipelineRef"},
+		},
+	}, {
+		name: "invalid pipeline task with taskRef and taskSpec and pipelineSpec",
+		p: PipelineTask{
+			Name:         "foo",
+			TaskRef:      &TaskRef{Name: "foo-task"},
+			TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskRef", "taskSpec", "pipelineSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with taskRef and pipelineRef and pipelineSpec",
+		p: PipelineTask{
+			Name:         "foo",
+			TaskRef:      &TaskRef{Name: "foo-task"},
+			PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskRef", "pipelineRef", "pipelineSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with taskSpec and pipelineRef and pipelineSpec",
+		p: PipelineTask{
+			Name:         "foo",
+			TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+			PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskSpec", "pipelineRef", "pipelineSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with taskRef and taskSpec and pipelineRef and pipelineSpec",
+		p: PipelineTask{
+			Name:         "foo",
+			TaskRef:      &TaskRef{Name: "foo-task"},
+			TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+			PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskRef", "taskSpec", "pipelineRef", "pipelineSpec"},
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -289,15 +289,37 @@ func (pt *PipelineTask) validateWorkspaces(workspaceNames sets.String) (errs *ap
 	return errs
 }
 
-// validateRefOrSpec validates at least one of taskRef or taskSpec is specified
+// validateRefOrSpec validates at least one of taskRef or taskSpec or pipelineRef or pipelineSpec is specified
 func (pt PipelineTask) validateRefOrSpec() (errs *apis.FieldError) {
-	// can't have both taskRef and taskSpec at the same time
-	if pt.TaskRef != nil && pt.TaskSpec != nil {
-		errs = errs.Also(apis.ErrMultipleOneOf("taskRef", "taskSpec"))
-	}
 	// Check that one of TaskRef and TaskSpec is present
-	if pt.TaskRef == nil && pt.TaskSpec == nil {
-		errs = errs.Also(apis.ErrMissingOneOf("taskRef", "taskSpec"))
+	if pt.TaskRef == nil && pt.TaskSpec == nil && pt.PipelineRef == nil && pt.PipelineSpec == nil {
+		errs = errs.Also(apis.ErrMissingOneOf("taskRef", "taskSpec", "pipelineRef", "pipelineSpec"))
+	}
+
+	nonNilFields := []string{}
+	// Increment the counter whenever we encounter a field which is set
+	fieldSetCount := 0
+	if pt.TaskRef != nil {
+		nonNilFields = append(nonNilFields, "taskRef")
+		fieldSetCount += 1
+	}
+	if pt.TaskSpec != nil {
+		nonNilFields = append(nonNilFields, "taskSpec")
+		fieldSetCount += 1
+	}
+	if pt.PipelineRef != nil {
+		nonNilFields = append(nonNilFields, "pipelineRef")
+		fieldSetCount += 1
+	}
+	if pt.PipelineSpec != nil {
+		nonNilFields = append(nonNilFields, "pipelineSpec")
+		fieldSetCount += 1
+	}
+
+	// If one of taskRef or taskSpec or pipelineRef or pipelineSpec is set, the fieldSetCount should
+	// exactly be 1, else multiple of them were set
+	if fieldSetCount > 1 {
+		errs = errs.Also(apis.ErrGeneric("expected exactly one, got multiple", nonNilFields...))
 	}
 	return errs
 }
@@ -327,6 +349,12 @@ func (pt PipelineTask) validateTask(ctx context.Context) (errs *apis.FieldError)
 	}
 	if pt.TaskRef != nil {
 		errs = errs.Also(pt.TaskRef.Validate(ctx).ViaField("taskRef"))
+	}
+	if pt.PipelineRef != nil {
+		errs = errs.Also(pt.PipelineRef.Validate(ctx).ViaField("pipelineRef"))
+	}
+	if pt.PipelineSpec != nil {
+		errs = errs.Also(pt.PipelineSpec.Validate(ctx).ViaField("pipelineSpec"))
 	}
 	return errs
 }


### PR DESCRIPTION
# Changes
This is the first of many pull requests to begin implementing [TEP-0056](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md)

1. Added `PipelineRef` and `PipelineSpec` to `PipelineTask`
2. Updated and added pipeline validation tests to reflect the above additions
3. Updated and added pipeline type tests to reflect the above additions
4. Added a initial set of docs and examples using the existing proposal

The changes in this PR does not change existing behavior and merely introduces fields to existing types

_Note: Pipelines in Pipelines is not yet implemented_

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
